### PR TITLE
Refactor: Update Python dependencies and fix server warnings

### DIFF
--- a/Server/Python/gesture_server.py
+++ b/Server/Python/gesture_server.py
@@ -31,7 +31,7 @@ except ImportError:
 
 # System control imports
 import websockets
-from websockets.server import WebSocketServerProtocol
+from websockets.asyncio.server import ServerConnection
 from websockets.exceptions import ConnectionClosed
 
 # Configure logging
@@ -460,7 +460,7 @@ class GestureServer:
         )
         logger.info(f"🔌 TCP server listening on {self.config.host}:{self.config.tcp_port}")
 
-    async def _process_message(self, raw_data: bytes, ws: Optional[WebSocketServerProtocol] = None):
+    async def _process_message(self, raw_data: bytes, ws: Optional[ServerConnection] = None):
         try:
             data = json.loads(raw_data)
             if data.get('type') == 'gesture_command':

--- a/Server/Python/requirements.txt
+++ b/Server/Python/requirements.txt
@@ -5,7 +5,7 @@
 asyncio-mqtt
 uvloop
 websockets
-pyautogui==0.9.54
+pyautogui
 
 # Network & Communication
 aiohttp

--- a/Server/Python/web_server.py
+++ b/Server/Python/web_server.py
@@ -11,6 +11,8 @@ from aiohttp import web
 if TYPE_CHECKING:
     from .gesture_server import GestureServer, ServerConfig
 
+GESTURE_SERVER_KEY = web.AppKey('gesture_server', "GestureServer")
+
 
 @web.middleware
 async def auth_middleware(request: web.Request, handler):
@@ -20,7 +22,7 @@ async def auth_middleware(request: web.Request, handler):
         return await handler(request)
 
     # Allow access if no token is configured on the server
-    server: "GestureServer" = request.app['gesture_server']
+    server: "GestureServer" = request.app[GESTURE_SERVER_KEY]
     if not server.config.secret_token:
         return await handler(request)
 
@@ -53,7 +55,7 @@ class WebServer:
         self.app = web.Application(middlewares=[auth_middleware])
         # Store a reference to the gesture_server instance in the app's context
         # so the middleware can access it.
-        self.app['gesture_server'] = self.gesture_server
+        self.app[GESTURE_SERVER_KEY] = self.gesture_server
         self._setup_routes()
 
     def _setup_routes(self):


### PR DESCRIPTION
This commit updates the Python server's dependencies and addresses several warnings that appeared after the update.

- Unpinned the `pyautogui` dependency in `Server/Python/requirements.txt` to allow for newer versions.
- Updated the `websockets` library usage in `gesture_server.py` to be compatible with newer versions, replacing the deprecated `WebSocketServerProtocol` with `ServerConnection`.
- Refactored the `aiohttp` web server in `web_server.py` to use the modern, type-safe `web.AppKey` for accessing shared application state, resolving a `NotAppKeyWarning`.

All tests were run successfully after these changes, ensuring no regressions were introduced.