### PR TITLE
feat: Implement remote Mac control via iPhone app

### DIFF
--- a/RemoteMacControl/iOS/ContentView.swift
+++ b/RemoteMacControl/iOS/ContentView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+// This data structure must exactly match the one on the macOS server application.
+struct ControlData: Codable {
+    let dx: Double
+    let dy: Double
+    let click: Bool
+}
+
+struct ContentView: View {
+    // Create and manage the lifecycle of our network client.
+    @StateObject private var client = iOSClient()
+
+    // State to track the drag gesture for calculating movement deltas.
+    @State private var lastDragPosition: CGPoint?
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Remote Mac Control")
+                .font(.largeTitle)
+
+            // Display the live connection status from the client.
+            Text("Status: \(client.connectionStatus)")
+                .foregroundColor(client.connectionStatus == "Connected" ? .green : .red)
+                .padding()
+                .background(Color.black.opacity(0.1))
+                .cornerRadius(10)
+
+            // The main area for gestures (the "trackpad").
+            ZStack {
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(Color.gray.opacity(0.2))
+
+                Text("Use this area as a trackpad")
+                    .foregroundColor(.gray)
+            }
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        let currentPosition = value.location
+
+                        // Calculate the delta from the last known position.
+                        let dx = currentPosition.x - (lastDragPosition ?? currentPosition).x
+                        let dy = currentPosition.y - (lastDragPosition ?? currentPosition).y
+
+                        // Send move data over the network via the client.
+                        client.send(dx: dx, dy: dy, click: false)
+
+                        // Update the last position for the next event.
+                        self.lastDragPosition = currentPosition
+                    }
+                    .onEnded { _ in
+                        // Reset when the user lifts their finger.
+                        self.lastDragPosition = nil
+                    }
+            )
+            .simultaneousGesture(
+                TapGesture()
+                    .onEnded {
+                        // Send click data over the network via the client.
+                        client.send(dx: 0, dy: 0, click: true)
+                        print("Tap detected! Sending click.")
+                    }
+            )
+
+            Spacer()
+        }
+        .padding()
+        .onAppear {
+            // Start searching for the Mac server when the view appears.
+            client.startBrowsing()
+        }
+        .onDisappear {
+            // Disconnect gracefully when the view is closed.
+            client.disconnect()
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/RemoteMacControl/iOS/iOSClient.swift
+++ b/RemoteMacControl/iOS/iOSClient.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Network
+
+class iOSClient: ObservableObject {
+    @Published var connectionStatus: String = "Disconnected"
+
+    private var browser: NWBrowser?
+    private var connection: NWConnection?
+
+    func startBrowsing() {
+        // Define the Bonjour service we are looking for. This must match the server.
+        let descriptor = NWBrowser.Descriptor.bonjour(type: "_remotemac._tcp", domain: "local")
+        browser = NWBrowser(for: descriptor, using: .tcp)
+
+        browser?.stateUpdateHandler = { newState in
+            switch newState {
+            case .ready:
+                self.connectionStatus = "Searching..."
+                print("Browser is ready and searching.")
+            case .failed(let error):
+                self.connectionStatus = "Search failed: \(error.localizedDescription)"
+                self.browser?.cancel()
+            default:
+                break
+            }
+        }
+
+        browser?.browseResultsChangedHandler = { results, changes in
+            if let firstResult = results.first {
+                // We found a service, now let's connect to it.
+                self.connect(to: firstResult.endpoint)
+                // Stop browsing once we've found one.
+                self.browser?.cancel()
+            }
+        }
+
+        print("Starting Bonjour browser...")
+        browser?.start(queue: .main)
+    }
+
+    private func connect(to endpoint: NWEndpoint) {
+        // Avoid creating multiple connections
+        guard connection == nil else { return }
+
+        print("Connecting to endpoint: \(endpoint)")
+        connection = NWConnection(to: endpoint, using: .tcp)
+
+        connection?.stateUpdateHandler = { newState in
+            DispatchQueue.main.async {
+                switch newState {
+                case .ready:
+                    self.connectionStatus = "Connected"
+                    print("Connection ready.")
+                case .failed(let error):
+                    self.connectionStatus = "Connection failed: \(error.localizedDescription)"
+                    self.connection?.cancel()
+                    self.connection = nil
+                case .cancelled:
+                    self.connectionStatus = "Disconnected"
+                    self.connection = nil
+                default:
+                    break
+                }
+            }
+        }
+
+        connection?.start(queue: .main)
+    }
+
+    func send(dx: Double, dy: Double, click: Bool) {
+        guard let connection = connection else {
+            print("Cannot send data, no connection.")
+            return
+        }
+
+        let controlData = ControlData(dx: dx, dy: dy, click: click)
+        do {
+            let data = try JSONEncoder().encode(controlData)
+            connection.send(content: data, completion: .idempotent)
+        } catch {
+            print("Failed to encode and send data: \(error)")
+        }
+    }
+
+    func disconnect() {
+        connection?.cancel()
+        connection = nil
+    }
+}

--- a/RemoteMacControl/macOS/main.swift
+++ b/RemoteMacControl/macOS/main.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Network
+import CoreGraphics
+
+class MacServer {
+    let listener: NWListener
+
+    // Define the Bonjour service
+    init() {
+        let parameters = NWParameters.tcp
+        // Using a custom service type "_remotemac._tcp"
+        let service = NWListener.Service(name: "RemoteMac", type: "_remotemac._tcp")
+
+        do {
+            listener = try NWListener(using: parameters, service: service)
+            print("Server: Bonjour service created.")
+        } catch {
+            fatalError("Server: Failed to create listener: \(error)")
+        }
+    }
+
+    func start() {
+        listener.stateUpdateHandler = { newState in
+            switch newState {
+            case .ready:
+                print("Server: Listener ready on port \(self.listener.port?.debugDescription ?? "N/A").")
+            case .failed(let error):
+                print("Server: Listener failed with error: \(error)")
+            default:
+                break
+            }
+        }
+
+        listener.newConnectionHandler = { newConnection in
+            print("Server: New connection received from \(newConnection.endpoint).")
+            let handler = ConnectionHandler(connection: newConnection)
+            handler.start()
+        }
+
+        // Start listening for connections.
+        listener.start(queue: .main)
+        print("Server: Listener started.")
+    }
+}
+
+// Simple structure to decode control data from the client
+struct ControlData: Codable {
+    let dx: Double       // Change in x
+    let dy: Double       // Change in y
+    let click: Bool      // Is it a click event?
+}
+
+class ConnectionHandler {
+    let connection: NWConnection
+
+    init(connection: NWConnection) {
+        self.connection = connection
+    }
+
+    func start() {
+        connection.stateUpdateHandler = { newState in
+            switch newState {
+            case .ready:
+                print("Connection: Ready to receive data.")
+                self.receive()
+            case .failed(let error):
+                print("Connection: Failed with error: \(error)")
+                self.connection.cancel()
+            default:
+                break
+            }
+        }
+        connection.start(queue: .main)
+    }
+
+    private func receive() {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { (data, _, isComplete, error) in
+            if let data = data, !data.isEmpty {
+                do {
+                    let controlData = try JSONDecoder().decode(ControlData.self, from: data)
+                    self.handleControlData(controlData)
+                } catch {
+                    print("Connection: Error decoding data: \(error)")
+                }
+            }
+
+            if isComplete {
+                print("Connection: Connection closed.")
+            } else if error == nil {
+                // If there's no error and the connection isn't complete, keep listening.
+                self.receive()
+            }
+        }
+    }
+
+    private func handleControlData(_ data: ControlData) {
+        // Get the current mouse location
+        guard let currentLocationCG = CGEvent(source: nil)?.location else {
+            print("Error: Could not get current mouse location.")
+            return
+        }
+        let currentLocation = NSPointToCGPoint(currentLocationCG)
+
+
+        let newLocation = CGPoint(x: currentLocation.x + CGFloat(data.dx), y: currentLocation.y + CGFloat(data.dy))
+
+        // Create a mouse move event
+        let moveEvent = CGEvent(
+            mouseEventSource: nil,
+            mouseType: .mouseMoved,
+            mouseCursorPosition: newLocation,
+            mouseButton: .left
+        )
+        moveEvent?.post(tap: .cgSessionEventTap)
+        // print("Moved mouse to \(newLocation.x), \(newLocation.y)") // For debugging
+
+        if data.click {
+            print("Executing click.")
+            // Create a mouse down event
+            let downEvent = CGEvent(
+                mouseEventSource: nil,
+                mouseType: .leftMouseDown,
+                mouseCursorPosition: newLocation,
+                mouseButton: .left
+            )
+            // Create a mouse up event
+            let upEvent = CGEvent(
+                mouseEventSource: nil,
+                mouseType: .leftMouseUp,
+                mouseCursorPosition: newLocation,
+                mouseButton: .left
+            )
+
+            downEvent?.post(tap: .cgSessionEventTap)
+            upEvent?.post(tap: .cgSessionEventTap)
+        }
+    }
+}
+
+
+// --- Main Execution ---
+print("Starting Remote Mac server...")
+let server = MacServer()
+server.start()
+
+// Keep the application running to listen for connections.
+RunLoop.main.run()


### PR DESCRIPTION
This commit introduces a new feature enabling you to control your Mac's cursor using an iPhone as a remote trackpad.

The implementation consists of two main components:
1.  A macOS server application (`main.swift`): A lightweight command-line tool that runs on the Mac. It uses the Network framework to advertise a Bonjour service (`_remotemac._tcp`) and listen for incoming client connections. Upon receiving control data, it uses the CoreGraphics framework to generate system-level mouse move and click events.
2.  An iOS client application (`ContentView.swift`, `iOSClient.swift`): A SwiftUI application that runs on the iPhone. It discovers the macOS server on the local network using Bonjour. The UI provides a trackpad area that captures drag and tap gestures, which are encoded as JSON and sent to the server in real-time.