### PR TITLE
Refactor: Clean up and enhance the Python server

### DIFF
--- a/Server/Python/config.yaml
+++ b/Server/Python/config.yaml
@@ -1,10 +1,14 @@
 # Default configuration for GestureControlPro Server
 # This file allows for easy customization of server settings.
 
+general:
+  version: "1.0.0"
+
 network:
   websocket_port: 8081
   udp_port: 9090
   tcp_port: 7070
+  dashboard_port: 8000
   host: "0.0.0.0"
   max_connections: 10
   buffer_size: 8192

--- a/Server/Python/requirements.txt
+++ b/Server/Python/requirements.txt
@@ -2,30 +2,22 @@
 # Version optimisée pour performance maximale
 
 # Core dependencies
-asyncio-mqtt
 uvloop
 websockets
 pyautogui
 pyperclip
+aiohttp
+pyyaml
+numpy
+scikit-learn
+translators
 
 # Network & Communication
-aiohttp
 websocket-client
-requests
-
-# Performance & Monitoring
-psutil
-scipy
-
-# Logging & Configuration
-pyyaml
-python-dotenv
-colorama
 
 # Optional: Computer Vision (pour extensions futures)
 opencv-python
 mediapipe
-translators
 
 # Optional: Machine Learning (pour prédiction avancée)
 # tensorflow-lite is not available on PyPI for Python 3.12 on this platform yet.
@@ -37,7 +29,3 @@ pytest
 pytest-asyncio
 black
 flake8
-
-# ML
-scikit-learn
-numpy


### PR DESCRIPTION
This commit introduces several improvements to the Python server component of GestureControlPro.

Key changes include:

- **Dependency Cleanup**: Removed several unused Python packages from `requirements.txt` (`asyncio-mqtt`, `requests`, `psutil`, `scipy`, `python-dotenv`, `colorama`) and an unused `LinearRegression` import from `gesture_server.py`. This reduces the project's footprint and simplifies dependency management.

- **Improved Configuration**:
  - The web dashboard port is now configurable via `config.yaml` (defaults to 8000), removing a hardcoded value.
  - The server's version number is now configurable in `config.yaml` and reflected in the API, instead of being hardcoded.

- **Enhanced Web API**:
  - The `/api/v1/status` endpoint now correctly reports the number of active TCP clients.
  - Configuration changes made via the `PUT /api/v1/config` endpoint are now persisted back to the `config.yaml` file, making them permanent across server restarts.
  - Enabled logging for configuration updates.

These changes make the server more robust, configurable, and easier to maintain.