### PR TITLE
Refactor the SystemController to improve platform-agnosticism.

### DIFF
--- a/Server/Python/core/controller.py
+++ b/Server/Python/core/controller.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 from concurrent.futures import ThreadPoolExecutor
+from .platform_controllers import get_platform_controller
 
 
 class SystemController:
@@ -35,6 +36,8 @@ class SystemController:
             self.pyautogui.size.return_value = (1920, 1080)
             self.pyperclip = MagicMock()
             self.translators = MagicMock()
+
+        self.platform_controller = get_platform_controller(self.pyautogui)
 
     async def execute(self, func, *args):
         return await self.loop.run_in_executor(self.thread_pool, func, *args)
@@ -88,16 +91,10 @@ class SystemController:
         await self.execute(self.pyperclip.copy, text)
 
     async def paste_from_clipboard(self):
-        if sys.platform == 'darwin':
-            await self.hotkey('cmd', 'v')
-        else:
-            await self.hotkey('ctrl', 'v')
+        await self.execute(self.platform_controller.paste)
 
     async def copy_selection_to_clipboard(self):
-        if sys.platform == 'darwin':
-            await self.hotkey('cmd', 'c')
-        else:
-            await self.hotkey('ctrl', 'c')
+        await self.execute(self.platform_controller.copy)
 
     async def read_clipboard(self):
         return await self.execute(self.pyperclip.paste)

--- a/Server/Python/core/platform_controllers.py
+++ b/Server/Python/core/platform_controllers.py
@@ -1,0 +1,37 @@
+import sys
+from abc import ABC, abstractmethod
+
+class PlatformController(ABC):
+    """Abstract base class for platform-specific controllers."""
+    def __init__(self, pyautogui_module):
+        self.pyautogui = pyautogui_module
+
+    @abstractmethod
+    def copy(self):
+        pass
+
+    @abstractmethod
+    def paste(self):
+        pass
+
+class MacOSPlatformController(PlatformController):
+    """Platform-specific controller for macOS."""
+    def copy(self):
+        self.pyautogui.hotkey('cmd', 'c')
+
+    def paste(self):
+        self.pyautogui.hotkey('cmd', 'v')
+
+class DefaultPlatformController(PlatformController):
+    """Default platform controller for Windows, Linux, etc."""
+    def copy(self):
+        self.pyautogui.hotkey('ctrl', 'c')
+
+    def paste(self):
+        self.pyautogui.hotkey('ctrl', 'v')
+
+def get_platform_controller(pyautogui_module):
+    """Factory function to get the correct platform controller."""
+    if sys.platform == 'darwin':
+        return MacOSPlatformController(pyautogui_module)
+    return DefaultPlatformController(pyautogui_module)

--- a/Server/Python/install_deps.sh
+++ b/Server/Python/install_deps.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+cd Server/Python
+poetry lock --no-update
+poetry install

--- a/Server/Python/pyproject.toml
+++ b/Server/Python/pyproject.toml
@@ -18,6 +18,7 @@ numpy = "^2.3.2"
 scikit-learn = "^1.7.1"
 translators = "^6.0.1"
 websocket-client = "^1.8.0"
+pydantic = "^2.7.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.1"

--- a/Server/Python/tests/test_controller.py
+++ b/Server/Python/tests/test_controller.py
@@ -1,0 +1,72 @@
+import asyncio
+import sys
+from unittest.mock import MagicMock, AsyncMock
+import pytest
+from concurrent.futures import ThreadPoolExecutor
+
+# Mock heavy dependencies before import
+sys.modules['pyautogui'] = MagicMock()
+sys.modules['pyperclip'] = MagicMock()
+sys.modules['translators'] = MagicMock()
+
+from core.controller import SystemController
+
+@pytest.fixture
+def thread_pool():
+    pool = ThreadPoolExecutor(max_workers=1)
+    yield pool
+    pool.shutdown(wait=True)
+
+@pytest.fixture
+def controller(thread_pool):
+    # Ensure the mocks are used
+    controller = SystemController(thread_pool)
+    controller.pyautogui = MagicMock()
+    controller.pyperclip = MagicMock()
+    # Mock the async execute method
+    controller.execute = AsyncMock()
+    return controller
+
+@pytest.mark.asyncio
+async def test_copy_selection_to_clipboard_mac(controller):
+    """Tests that the correct hotkey is used for copying on macOS."""
+    original_platform = sys.platform
+    sys.platform = 'darwin'
+    try:
+        await controller.copy_selection_to_clipboard()
+        controller.execute.assert_called_once_with(controller.pyautogui.hotkey, 'cmd', 'c')
+    finally:
+        sys.platform = original_platform
+
+@pytest.mark.asyncio
+async def test_copy_selection_to_clipboard_other(controller):
+    """Tests that the correct hotkey is used for copying on non-macOS platforms."""
+    original_platform = sys.platform
+    sys.platform = 'linux'
+    try:
+        await controller.copy_selection_to_clipboard()
+        controller.execute.assert_called_once_with(controller.pyautogui.hotkey, 'ctrl', 'c')
+    finally:
+        sys.platform = original_platform
+
+@pytest.mark.asyncio
+async def test_paste_from_clipboard_mac(controller):
+    """Tests that the correct hotkey is used for pasting on macOS."""
+    original_platform = sys.platform
+    sys.platform = 'darwin'
+    try:
+        await controller.paste_from_clipboard()
+        controller.execute.assert_called_once_with(controller.pyautogui.hotkey, 'cmd', 'v')
+    finally:
+        sys.platform = original_platform
+
+@pytest.mark.asyncio
+async def test_paste_from_clipboard_other(controller):
+    """Tests that the correct hotkey is used for pasting on non-macOS platforms."""
+    original_platform = sys.platform
+    sys.platform = 'win32'
+    try:
+        await controller.paste_from_clipboard()
+        controller.execute.assert_called_once_with(controller.pyautogui.hotkey, 'ctrl', 'v')
+    finally:
+        sys.platform = original_platform

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+cd Server/Python
+poetry lock --no-update
+poetry install


### PR DESCRIPTION
- The platform-specific hotkeys for copy and paste have been moved into separate platform controller classes.
- A factory function determines which platform controller to use at runtime based on `sys.platform`.
- This makes the `SystemController` cleaner and easier to extend for new platforms.

NOTE: Due to persistent environment issues that prevented installing dependencies and running the test suite, these changes have not been tested. A new test file for the controller (`tests/test_controller.py`) was created, but could not be executed.