### PR TITLE
refactor(server): Remove unused websocket-client dependency

### DIFF
--- a/Server/Python/poetry.lock
+++ b/Server/Python/poetry.lock
@@ -2624,23 +2624,6 @@ files = [
 ]
 
 [[package]]
-name = "websocket-client"
-version = "1.8.0"
-description = "WebSocket client for Python with low level API options"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526"},
-    {file = "websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da"},
-]
-
-[package.extras]
-docs = ["Sphinx (>=6.0)", "myst-parser (>=2.0.0)", "sphinx-rtd-theme (>=1.1.0)"]
-optional = ["python-socks", "wsaccel"]
-test = ["websockets"]
-
-[[package]]
 name = "websockets"
 version = "15.0.1"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
@@ -2841,4 +2824,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "f6281de99170feac310123dca34abbaf1d2d52c7aa41000fee5649b21f470e3a"
+content-hash = "1e9ea384f6b7e5662d0dfe1143f68da3468b16ba2e69685b7ede4163f6ba2e42"

--- a/Server/Python/pyproject.toml
+++ b/Server/Python/pyproject.toml
@@ -18,7 +18,6 @@ pyyaml = "^6.0.2"
 numpy = "^2.3.2"
 scikit-learn = "^1.7.1"
 translators = "^6.0.1"
-websocket-client = "^1.8.0"
 pydantic = "^2.7.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
The 'websocket-client' package was listed as a dependency for the Python server, but it was not being used in the codebase. The project already uses the 'websockets' library for handling WebSocket communication.

Removing this unused dependency simplifies the project, reduces the overall size of the environment, and streamlines dependency management.